### PR TITLE
docs(auth): SAFE-AUTH for MCP — baseline flows + MUST/SHOULD checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,7 @@ The SAFE-MCP framework defines 14 tactics that align with the MITRE ATT&CK metho
 - Map these techniques to your specific MCP deployment for risk assessment
 - Prioritize mitigation based on your threat model and the techniques most relevant to your environment
 - Regular review as new techniques emerge in the rapidly evolving MCP threat landscape
+
+## Authentication
+
+See **[SAFE-AUTH for MCP](./docs/auth/overview.md)** for baseline flows and the MUST/SHOULD checklist.

--- a/docs/auth/overview.md
+++ b/docs/auth/overview.md
@@ -1,0 +1,58 @@
+<!-- Licensed under CC-BY-4.0 -->
+
+# SAFE-AUTH for MCP — Overview
+
+**Goal.** Provide a vendor-neutral authentication baseline so MCP implementations are **safe by default** for humans, headless agents, and tool servers.
+
+## Design principles
+- **Least privilege per tool**: scopes and **audience** are bound to the *next hop* (specific tool/service), never broad.
+- **Short-lived tokens** bound to the caller (**DPoP or mTLS**) to kill replay.
+- **Explicit delegation** across agent→agent→tool hops (token **exchange** each hop; never forward a broad token).
+- **Observable by design**: structured telemetry on every tool call for audits and incident response.
+
+## Roles in MCP auth
+- **Human Operator** (user)
+- **MCP Client/Agent** (orchestrates tools)
+- **MCP Server / Tool Host** (executes tool calls)
+- **Authorization Server (AS)** (OIDC/OAuth2 provider)
+
+## Threats this baseline addresses
+- **Authorization server mix-up / CSRF** → OIDC Authorization Code **with PKCE**, `state`, `nonce`, **issuer pinning**.
+- **Token replay** → **DPoP or mTLS** token binding + access token **TTL ≤ 10 minutes**.
+- **Token audience confusion** (token reused across tools) → token `aud` **must equal the exact next tool/service**.
+- **Delegation drift** (multi-agent hops drop user/intent context) → **RFC 8693 Token Exchange** per hop + re-bind `aud`.
+- **JWKS staleness / `kid` collision** → JWKS **cache ≤ 15m**, overlap rotation, strict deny on unknown `kid`.
+
+## Canonical flows (mermaid)
+### Human → MCP Client → MCP Server (OIDC Auth Code + PKCE)
+```mermaid
+sequenceDiagram
+participant User
+participant Client as MCP Client
+participant AS as Authorization Server
+participant Server as MCP Server/Tool
+User->>Client: Start sign-in
+Client->>AS: /authorize (response_type=code, PKCE, state, nonce)
+AS-->>Client: Auth code (redirect)
+Client->>AS: /token (code + code_verifier)
+AS-->>Client: access_token (bound via DPoP/mTLS), id_token
+Client->>Server: Tool call (Authorization: DPoP <proof>; token aud=Server)
+Server-->>Client: Result (+ audit_id)
+
+cat > docs/auth/checklist.md <<'EOF'
+<!-- Licensed under CC-BY-4.0 -->
+
+# SAFE-AUTH Checklist (MUST / SHOULD / MAY)
+
+| Level | Control | Why |
+|---|---|---|
+| **MUST** | Human login uses **OIDC Authorization Code + PKCE** (no implicit) with `state`, `nonce`, issuer pinning | Prevent code interception, AS mix-up, CSRF |
+| **MUST** | Machine/agent calls use **DPoP or mTLS** token binding | Prevent replay |
+| **MUST** | **Audience (`aud`) per hop = exact next tool/service** | Stop token reuse across tools |
+| **MUST** | **Access token TTL ≤ 10 minutes** | Shrink exfiltration window |
+| **MUST** | **JWKS cache ≤ 15 minutes** and rotation SOP | Avoid stale keys / `kid` swap |
+| **MUST** | **Structured telemetry** per call | Audits & forensics |
+| **SHOULD** | **RFC 8693 Token Exchange** per hop | Preserve delegation context |
+| **SHOULD** | Deny on context loss | Fail-safe default |
+| **SHOULD** | Rate-limit auth endpoints | Abuse control |
+| **MAY** | PAR/JAR, CAEP, continuous eval | Hardening options |


### PR DESCRIPTION
This PR introduces a vendor-neutral SAFE-AUTH baseline for MCP.

### Adds
- `docs/auth/overview.md` — goals, principles, roles, threats; canonical human (OIDC+PKCE) and headless (Client Credentials + DPoP/mTLS) flows with Mermaid diagrams.
- `docs/auth/checklist.md` — MUST/SHOULD/MAY controls (PKCE, audience per hop, token binding, TTLs, JWKS rotation, structured telemetry).
- `README.md` pointer to the above.

### Intent
Provide an MCP-authentication baseline that is safe by default for implementers:
- Humans, headless agents, and tool servers.
- Explicit delegation, narrow scopes, per-hop binding.
- Copy-paste checklist for audits and incident response.

Happy to refine or split if maintainers prefer.