### PR TITLE
docs(auth): delegation drift + per-hop mitigations

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,7 @@ The SAFE-MCP framework defines 14 tactics that align with the MITRE ATT&CK metho
 - Map these techniques to your specific MCP deployment for risk assessment
 - Prioritize mitigation based on your threat model and the techniques most relevant to your environment
 - Regular review as new techniques emerge in the rapidly evolving MCP threat landscape
+
+## Authentication
+
+See **[SAFE-AUTH for MCP](./docs/auth/overview.md)** for baseline flows and the MUST/SHOULD checklist.

--- a/docs/auth/conformance-template.yaml
+++ b/docs/auth/conformance-template.yaml
@@ -1,0 +1,67 @@
+# SAFE-AUTH Conformance Template
+# status: todo | partial | done
+meta:
+  system: "<name>"
+  owner: "<team-or-contact>"
+  reviewed_at: "<YYYY-MM-DD>"
+
+controls:
+  - id: AUTH-001
+    name: OIDC Authorization Code + PKCE
+    level: MUST
+    status: todo
+    evidence: ["<oidc client config>"]
+
+  - id: AUTH-002
+    name: state + nonce + issuer pinning
+    level: MUST
+    status: todo
+    evidence: []
+
+  - id: AUTH-003
+    name: DPoP or mTLS token binding
+    level: MUST
+    status: todo
+    evidence: ["<gateway/policy link>"]
+
+  - id: AUTH-004
+    name: aud = exact next tool/service
+    level: MUST
+    status: todo
+    evidence: ["<JWT sample showing aud>"]
+
+  - id: AUTH-005
+    name: Access token TTL ≤ 10 minutes
+    level: MUST
+    status: todo
+    evidence: []
+
+  - id: AUTH-006
+    name: JWKS cache ≤ 15 minutes + rotation SOP
+    level: MUST
+    status: todo
+    evidence: ["<rotation runbook link>"]
+
+  - id: AUTH-007
+    name: Structured telemetry fields present per call
+    level: MUST
+    status: todo
+    evidence: ["<log sample>"]
+
+  - id: AUTH-008
+    name: RFC 8693 Token Exchange per hop
+    level: SHOULD
+    status: partial
+    evidence: []
+
+  - id: AUTH-009
+    name: Deny on context loss (missing aud/trace_id)
+    level: SHOULD
+    status: partial
+    evidence: []
+
+  - id: AUTH-010
+    name: Rate-limit auth endpoints & tool calls
+    level: SHOULD
+    status: partial
+    evidence: []

--- a/docs/auth/overview.md
+++ b/docs/auth/overview.md
@@ -1,0 +1,58 @@
+<!-- Licensed under CC-BY-4.0 -->
+
+# SAFE-AUTH for MCP — Overview
+
+**Goal.** Provide a vendor-neutral authentication baseline so MCP implementations are **safe by default** for humans, headless agents, and tool servers.
+
+## Design principles
+- **Least privilege per tool**: scopes and **audience** are bound to the *next hop* (specific tool/service), never broad.
+- **Short-lived tokens** bound to the caller (**DPoP or mTLS**) to kill replay.
+- **Explicit delegation** across agent→agent→tool hops (token **exchange** each hop; never forward a broad token).
+- **Observable by design**: structured telemetry on every tool call for audits and incident response.
+
+## Roles in MCP auth
+- **Human Operator** (user)
+- **MCP Client/Agent** (orchestrates tools)
+- **MCP Server / Tool Host** (executes tool calls)
+- **Authorization Server (AS)** (OIDC/OAuth2 provider)
+
+## Threats this baseline addresses
+- **Authorization server mix-up / CSRF** → OIDC Authorization Code **with PKCE**, `state`, `nonce`, **issuer pinning**.
+- **Token replay** → **DPoP or mTLS** token binding + access token **TTL ≤ 10 minutes**.
+- **Token audience confusion** (token reused across tools) → token `aud` **must equal the exact next tool/service**.
+- **Delegation drift** (multi-agent hops drop user/intent context) → **RFC 8693 Token Exchange** per hop + re-bind `aud`.
+- **JWKS staleness / `kid` collision** → JWKS **cache ≤ 15m**, overlap rotation, strict deny on unknown `kid`.
+
+## Canonical flows (mermaid)
+### Human → MCP Client → MCP Server (OIDC Auth Code + PKCE)
+```mermaid
+sequenceDiagram
+participant User
+participant Client as MCP Client
+participant AS as Authorization Server
+participant Server as MCP Server/Tool
+User->>Client: Start sign-in
+Client->>AS: /authorize (response_type=code, PKCE, state, nonce)
+AS-->>Client: Auth code (redirect)
+Client->>AS: /token (code + code_verifier)
+AS-->>Client: access_token (bound via DPoP/mTLS), id_token
+Client->>Server: Tool call (Authorization: DPoP <proof>; token aud=Server)
+Server-->>Client: Result (+ audit_id)
+
+cat > docs/auth/checklist.md <<'EOF'
+<!-- Licensed under CC-BY-4.0 -->
+
+# SAFE-AUTH Checklist (MUST / SHOULD / MAY)
+
+| Level | Control | Why |
+|---|---|---|
+| **MUST** | Human login uses **OIDC Authorization Code + PKCE** (no implicit) with `state`, `nonce`, issuer pinning | Prevent code interception, AS mix-up, CSRF |
+| **MUST** | Machine/agent calls use **DPoP or mTLS** token binding | Prevent replay |
+| **MUST** | **Audience (`aud`) per hop = exact next tool/service** | Stop token reuse across tools |
+| **MUST** | **Access token TTL ≤ 10 minutes** | Shrink exfiltration window |
+| **MUST** | **JWKS cache ≤ 15 minutes** and rotation SOP | Avoid stale keys / `kid` swap |
+| **MUST** | **Structured telemetry** per call | Audits & forensics |
+| **SHOULD** | **RFC 8693 Token Exchange** per hop | Preserve delegation context |
+| **SHOULD** | Deny on context loss | Fail-safe default |
+| **SHOULD** | Rate-limit auth endpoints | Abuse control |
+| **MAY** | PAR/JAR, CAEP, continuous eval | Hardening options |

--- a/docs/auth/threat-control-matrix.md
+++ b/docs/auth/threat-control-matrix.md
@@ -1,0 +1,12 @@
+<!-- Licensed under CC-BY-4.0 -->
+
+# Threat → Control Matrix (SAFE-AUTH)
+
+| Threat | Primary Controls (MUST) | Secondary (SHOULD/MAY) | Evidence to Collect |
+|---|---|---|---|
+| AS mix-up / CSRF | OIDC Auth Code + **PKCE**, `state`, `nonce`, **issuer pinning** | PAR/JAR | OIDC client config, redirect URI list, issuer metadata |
+| Token replay | **DPoP or mTLS** binding; **TTL ≤10m** | CAEP/continuous evaluation | DPoP verification logs, TLS/mTLS policy, token lifetime |
+| Token audience confusion | **`aud` = exact next tool/service** | Per-tool scope map | JWT sample with `aud`, tool registry mapping |
+| Delegation drift (multi-hop) | **RFC 8693 Token Exchange** per hop; re-bind `aud` | Deny on missing `trace_id` / `aud` | Token Exchange config, hop-by-hop logs |
+| JWKS staleness / `kid` collision | **JWKS cache ≤15m**; rotation SOP; deny unknown `kid` | Overlap-period alerts | JWKS headers, rotation runbook, error logs |
+| Observability gap | **Structured telemetry on every tool call** | Centralized log routing | Field schema adoption, sample NDJSON |

--- a/mitigations/SAFE-M1001-auth-delegation.md
+++ b/mitigations/SAFE-M1001-auth-delegation.md
@@ -1,0 +1,30 @@
+<!-- Licensed under CC-BY-4.0 -->
+
+# SAFE-M1001: Per-Hop Delegation Mitigations
+
+**Objective.** Ensure every hop in a delegation chain has a *fresh*, *narrow*, and *proof-of-possession* bound token for the exact next audience.
+
+## Controls (map to checklist IDs)
+- **MUST** AUTH-003: DPoP or mTLS binding on all tokens used for tool calls
+- **MUST** AUTH-004: `aud` = exact next tool/service (no wildcards)
+- **MUST** AUTH-005: Access token TTL ≤ 10 minutes (shorter for sensitive tools)
+- **MUST** AUTH-006: JWKS cache ≤ 15 minutes; deny unknown `kid`; rotation SOP
+- **SHOULD** AUTH-008: RFC 8693 Token Exchange per hop (re-bind audience)
+- **SHOULD** AUTH-009: Deny on missing `aud`/`trace_id`; fail-safe default
+
+## Implementation pattern (per hop)
+1. **Token Exchange**: Exchange incoming token for a new token with `aud=<next>` and TTL ≤ 10m.
+2. **Bind PoP**: Use DPoP (HTTP) or mTLS (gateway) so token is sender-constrained.
+3. **Validate**: On receipt, verify `aud`, TTL, PoP, and `kid` exists in current JWKS.
+4. **Emit telemetry**: Log fields from `docs/auth/telemetry-schema.md` (incl. `trace_id`, `aud`, `jti`, `dpop_jkt`).
+5. **Deny on context loss**: If `aud` mismatched/missing or PoP not present → hard deny + audit event.
+
+## Example enforcement pseudo
+
+## Example enforcement pseudo
+
+
+**References.**
+- `docs/auth/threat-control-matrix.md`
+- `docs/auth/flows/headless-agent.md`
+- RFC 8693 (Token Exchange)


### PR DESCRIPTION
**Summary**
Adds SAFE-AUTH docs for multi-hop delegation risk and concrete per-hop mitigations.

**Included**
- `docs/auth/SAFE-M1001-delegation-drift.md` — threat write-up (why it happens, kill chain, red flags).
- `mitigations/SAFE-M1001-auth-delegation.md` — per-hop controls + enforcement pseudo.
- Link from `docs/auth/overview.md`.

**Why**
Prevents token re-use/widening across hops by requiring PoP, per-hop audience binding, short TTLs, JWKS rotation hygiene, and structured telemetry (`trace_id`, `jti`, `aud`, `dpop_jkt`).

**Notes**
Happy to adjust scope, split, or refine per maintainer guidance.