### PR TITLE
docs(auth): JWKS hygiene — cache ≤15m, deny unknown kid; rotation SOP + alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,7 @@ The SAFE-MCP framework defines 14 tactics that align with the MITRE ATT&CK metho
 - Map these techniques to your specific MCP deployment for risk assessment
 - Prioritize mitigation based on your threat model and the techniques most relevant to your environment
 - Regular review as new techniques emerge in the rapidly evolving MCP threat landscape
+
+## Authentication
+
+See **[SAFE-AUTH for MCP](./docs/auth/overview.md)** for baseline flows and the MUST/SHOULD checklist.

--- a/alerts/jwks-hygiene.md
+++ b/alerts/jwks-hygiene.md
@@ -1,0 +1,17 @@
+# Alerts: JWKS Hygiene
+
+- **Unknown kid deny**
+  - Condition: `result == "deny_unknown_kid"` (rate > 0 for 2m)
+  - Action: page on-call; create incident.
+
+- **Stale JWKS cache**
+  - Condition: `jwks_cache_age_ms > 900000` sustained 5m (per issuer)
+  - Action: warn (SLO); if > 20m escalate.
+
+- **Rotation window exceeded**
+  - Condition: both old+new keys observed > 60m
+  - Action: ticket + on-call notification.
+
+- **Key age exceeds policy**
+  - Condition: signer `kid` unchanged > 90d
+  - Action: ticket; schedule rotation.

--- a/docs/auth/checklist.md
+++ b/docs/auth/checklist.md
@@ -1,0 +1,2 @@
+
+> Evidence ideas for AUTH-006: deny logs for unknown kid, JWKS cache-age panel, rotation ticket <=30d.

--- a/docs/auth/conformance-template.yaml
+++ b/docs/auth/conformance-template.yaml
@@ -1,0 +1,67 @@
+# SAFE-AUTH Conformance Template
+# status: todo | partial | done
+meta:
+  system: "<name>"
+  owner: "<team-or-contact>"
+  reviewed_at: "<YYYY-MM-DD>"
+
+controls:
+  - id: AUTH-001
+    name: OIDC Authorization Code + PKCE
+    level: MUST
+    status: todo
+    evidence: ["<oidc client config>"]
+
+  - id: AUTH-002
+    name: state + nonce + issuer pinning
+    level: MUST
+    status: todo
+    evidence: []
+
+  - id: AUTH-003
+    name: DPoP or mTLS token binding
+    level: MUST
+    status: todo
+    evidence: ["<gateway/policy link>"]
+
+  - id: AUTH-004
+    name: aud = exact next tool/service
+    level: MUST
+    status: todo
+    evidence: ["<JWT sample showing aud>"]
+
+  - id: AUTH-005
+    name: Access token TTL ≤ 10 minutes
+    level: MUST
+    status: todo
+    evidence: []
+
+  - id: AUTH-006
+    name: JWKS cache ≤ 15 minutes + rotation SOP
+    level: MUST
+    status: todo
+    evidence: ["<rotation runbook link>"]
+
+  - id: AUTH-007
+    name: Structured telemetry fields present per call
+    level: MUST
+    status: todo
+    evidence: ["<log sample>"]
+
+  - id: AUTH-008
+    name: RFC 8693 Token Exchange per hop
+    level: SHOULD
+    status: partial
+    evidence: []
+
+  - id: AUTH-009
+    name: Deny on context loss (missing aud/trace_id)
+    level: SHOULD
+    status: partial
+    evidence: []
+
+  - id: AUTH-010
+    name: Rate-limit auth endpoints & tool calls
+    level: SHOULD
+    status: partial
+    evidence: []

--- a/docs/auth/jwks-hygiene.md
+++ b/docs/auth/jwks-hygiene.md
@@ -1,0 +1,37 @@
+# SAFE-AUTH: JWKS Hygiene & Rotation
+
+**Why it matters.** Stale or mismatched keys let attackers replay or impersonate tokens; unknown `kid` lets rogue keys slip in; long rotation windows widen blast radius.
+
+## MUST
+- **Cache TTL ≤ 15 minutes** for issuer JWKS.
+- **Deny unknown `kid`** (hard fail; emit audit).
+- **Overlapping rotation window ≤ 1 hour** (old+new keys concurrently valid).
+- **Alert on cache age > TTL** (fetch failures or stuck caches).
+
+## SHOULD
+- **Rotation cadence ≤ 30 days** (shorter for high-risk).
+- **No static keys**; automation only.
+- **Key provenance** recorded (KMS/CloudHSM).
+
+## Telemetry (per auth decision)
+Record at least:
+- `trace_id`, `aud`, `jti`, `kid`, `jwks_cache_age_ms`, `jwks_source` (`remote|cache`), `result` (`success|deny_unknown_kid|deny_stale_jwks|error`).
+
+## Alerts (see alerts/jwks-hygiene.md)
+- Unknown `kid` deny.
+- `jwks_cache_age_ms` > 15m for >5m.
+- Rotation overlap > 60m.
+- Same `kid` age > 90d.
+
+## Runbook (see runbooks/jwks-rotation-sop.md)
+- Pre-announce, rotate, verify, and rollback steps with checkpoints.
+
+## Evidence to attach (for checklist)
+- Screenshot/log of deny-on-unknown-kid.
+- Monitoring panel showing JWKS cache age distribution.
+- Rotation change record (ticket/PR) within 30d.
+
+## References
+- RFC 7517 (JWK), RFC 7518/7519 (JWS/JWT)
+- SAFE-AUTH Checklist: AUTH-006 (JWKS cache ≤ 15m; deny unknown `kid`)
+- Telemetry schema v1 + validators

--- a/docs/auth/overview.md
+++ b/docs/auth/overview.md
@@ -1,0 +1,58 @@
+<!-- Licensed under CC-BY-4.0 -->
+
+# SAFE-AUTH for MCP — Overview
+
+**Goal.** Provide a vendor-neutral authentication baseline so MCP implementations are **safe by default** for humans, headless agents, and tool servers.
+
+## Design principles
+- **Least privilege per tool**: scopes and **audience** are bound to the *next hop* (specific tool/service), never broad.
+- **Short-lived tokens** bound to the caller (**DPoP or mTLS**) to kill replay.
+- **Explicit delegation** across agent→agent→tool hops (token **exchange** each hop; never forward a broad token).
+- **Observable by design**: structured telemetry on every tool call for audits and incident response.
+
+## Roles in MCP auth
+- **Human Operator** (user)
+- **MCP Client/Agent** (orchestrates tools)
+- **MCP Server / Tool Host** (executes tool calls)
+- **Authorization Server (AS)** (OIDC/OAuth2 provider)
+
+## Threats this baseline addresses
+- **Authorization server mix-up / CSRF** → OIDC Authorization Code **with PKCE**, `state`, `nonce`, **issuer pinning**.
+- **Token replay** → **DPoP or mTLS** token binding + access token **TTL ≤ 10 minutes**.
+- **Token audience confusion** (token reused across tools) → token `aud` **must equal the exact next tool/service**.
+- **Delegation drift** (multi-agent hops drop user/intent context) → **RFC 8693 Token Exchange** per hop + re-bind `aud`.
+- **JWKS staleness / `kid` collision** → JWKS **cache ≤ 15m**, overlap rotation, strict deny on unknown `kid`.
+
+## Canonical flows (mermaid)
+### Human → MCP Client → MCP Server (OIDC Auth Code + PKCE)
+```mermaid
+sequenceDiagram
+participant User
+participant Client as MCP Client
+participant AS as Authorization Server
+participant Server as MCP Server/Tool
+User->>Client: Start sign-in
+Client->>AS: /authorize (response_type=code, PKCE, state, nonce)
+AS-->>Client: Auth code (redirect)
+Client->>AS: /token (code + code_verifier)
+AS-->>Client: access_token (bound via DPoP/mTLS), id_token
+Client->>Server: Tool call (Authorization: DPoP <proof>; token aud=Server)
+Server-->>Client: Result (+ audit_id)
+
+cat > docs/auth/checklist.md <<'EOF'
+<!-- Licensed under CC-BY-4.0 -->
+
+# SAFE-AUTH Checklist (MUST / SHOULD / MAY)
+
+| Level | Control | Why |
+|---|---|---|
+| **MUST** | Human login uses **OIDC Authorization Code + PKCE** (no implicit) with `state`, `nonce`, issuer pinning | Prevent code interception, AS mix-up, CSRF |
+| **MUST** | Machine/agent calls use **DPoP or mTLS** token binding | Prevent replay |
+| **MUST** | **Audience (`aud`) per hop = exact next tool/service** | Stop token reuse across tools |
+| **MUST** | **Access token TTL ≤ 10 minutes** | Shrink exfiltration window |
+| **MUST** | **JWKS cache ≤ 15 minutes** and rotation SOP | Avoid stale keys / `kid` swap |
+| **MUST** | **Structured telemetry** per call | Audits & forensics |
+| **SHOULD** | **RFC 8693 Token Exchange** per hop | Preserve delegation context |
+| **SHOULD** | Deny on context loss | Fail-safe default |
+| **SHOULD** | Rate-limit auth endpoints | Abuse control |
+| **MAY** | PAR/JAR, CAEP, continuous eval | Hardening options |

--- a/docs/auth/overview.md
+++ b/docs/auth/overview.md
@@ -56,3 +56,7 @@ cat > docs/auth/checklist.md <<'EOF'
 | **SHOULD** | Deny on context loss | Fail-safe default |
 | **SHOULD** | Rate-limit auth endpoints | Abuse control |
 | **MAY** | PAR/JAR, CAEP, continuous eval | Hardening options |
+
+- Telemetry: [Schema](./telemetry-schema.md) ·
+  [Validators](./telemetry-validators.md) ·
+  [Sample NDJSON](../../examples/telemetry/sample.ndjson)

--- a/docs/auth/overview.md
+++ b/docs/auth/overview.md
@@ -60,3 +60,5 @@ cat > docs/auth/checklist.md <<'EOF'
 - Telemetry: [Schema](./telemetry-schema.md) ·
   [Validators](./telemetry-validators.md) ·
   [Sample NDJSON](../../examples/telemetry/sample.ndjson)
+
+- JWKS Hygiene: see [docs/auth/jwks-hygiene.md](./docs/auth/jwks-hygiene.md), [alerts/jwks-hygiene.md](./alerts/jwks-hygiene.md), and [runbooks/jwks-rotation-sop.md](./runbooks/jwks-rotation-sop.md).

--- a/docs/auth/telemetry-schema.md
+++ b/docs/auth/telemetry-schema.md
@@ -1,0 +1,8 @@
+
+## Validators
+See [telemetry-validators](./telemetry-validators.md) and
+[sample NDJSON](../../examples/telemetry/sample.ndjson).
+
+## Validators
+See [telemetry-validators](./telemetry-validators.md) and
+[sample NDJSON](../../examples/telemetry/sample.ndjson).

--- a/docs/auth/telemetry-validators.md
+++ b/docs/auth/telemetry-validators.md
@@ -1,0 +1,37 @@
+# SAFE-AUTH Telemetry Validators (v1)
+
+**Required per call:** `trace_id`, `ts`, `tool`, `client_id`, `sub_or_user`, `aud`, `jti`, and `dpop_jkt` when PoP policy is enabled.
+
+## Reject if
+- `aud` ≠ invoked tool/service id
+- `jti` is reused within the token TTL window
+- `dpop_jkt` missing when PoP is required
+- `trace_id` missing or empty
+
+## Recommended checks
+- Clock skew ≤ 60s between `ts` values on same `trace_id`
+- Monotonic `ts` per `trace_id`
+- Result not `"success"` without an auth decision log
+
+## Example (NDJSON)
+See `examples/telemetry/sample.ndjson`.
+
+## Quick local checks (jq)
+```bash
+# 1) Missing trace_id
+jq -c 'select(has("trace_id")|not)' examples/telemetry/sample.ndjson
+
+# 2) aud mismatch (expect mcp://tool/ingest)
+jq -c 'select(.aud != "mcp://tool/ingest")' examples/telemetry/sample.ndjson
+
+# 3) Duplicate jti within the file (naive local check)
+jq -r .jti examples/telemetry/sample.n
+
+
+---
+
+### 3) Append a tiny “Validators” section to your existing schema (safe even if it already exists)
+```bash
+printf "\n## Validators\nSee [telemetry-validators](./telemetry-validators.md) and [sample NDJSON](../../examples/telemetry/sample.ndjson).\n" >> docs/auth/telemetry-schema.md
+
+eof

--- a/docs/auth/threat-control-matrix.md
+++ b/docs/auth/threat-control-matrix.md
@@ -1,0 +1,12 @@
+<!-- Licensed under CC-BY-4.0 -->
+
+# Threat → Control Matrix (SAFE-AUTH)
+
+| Threat | Primary Controls (MUST) | Secondary (SHOULD/MAY) | Evidence to Collect |
+|---|---|---|---|
+| AS mix-up / CSRF | OIDC Auth Code + **PKCE**, `state`, `nonce`, **issuer pinning** | PAR/JAR | OIDC client config, redirect URI list, issuer metadata |
+| Token replay | **DPoP or mTLS** binding; **TTL ≤10m** | CAEP/continuous evaluation | DPoP verification logs, TLS/mTLS policy, token lifetime |
+| Token audience confusion | **`aud` = exact next tool/service** | Per-tool scope map | JWT sample with `aud`, tool registry mapping |
+| Delegation drift (multi-hop) | **RFC 8693 Token Exchange** per hop; re-bind `aud` | Deny on missing `trace_id` / `aud` | Token Exchange config, hop-by-hop logs |
+| JWKS staleness / `kid` collision | **JWKS cache ≤15m**; rotation SOP; deny unknown `kid` | Overlap-period alerts | JWKS headers, rotation runbook, error logs |
+| Observability gap | **Structured telemetry on every tool call** | Centralized log routing | Field schema adoption, sample NDJSON |

--- a/examples/telemetry/sample.ndjson
+++ b/examples/telemetry/sample.ndjson
@@ -1,0 +1,2 @@
+{"trace_id":"tr_001","ts":"2025-08-16T19:20:30Z","tool":"mcp://tool/ingest","client_id":"agent-42","sub_or_user":"user-123","aud":"mcp://tool/ingest","jti":"jti-001","dpop_jkt":"thp-abc123","method":"POST","target":"/tools/ingest","result":"success"}
+{"trace_id":"tr_001","ts":"2025-08-16T19:20:31Z","tool":"mcp://tool/ingest","client_id":"agent-42","sub_or_user":"user-123","aud":"mcp://tool/ingest","jti":"jti-002","dpop_jkt":"thp-abc123","method":"POST","target":"/tools/ingest","result":"success"}

--- a/mitigations/SAFE-M1001-auth-delegation.md
+++ b/mitigations/SAFE-M1001-auth-delegation.md
@@ -1,0 +1,30 @@
+<!-- Licensed under CC-BY-4.0 -->
+
+# SAFE-M1001: Per-Hop Delegation Mitigations
+
+**Objective.** Ensure every hop in a delegation chain has a *fresh*, *narrow*, and *proof-of-possession* bound token for the exact next audience.
+
+## Controls (map to checklist IDs)
+- **MUST** AUTH-003: DPoP or mTLS binding on all tokens used for tool calls
+- **MUST** AUTH-004: `aud` = exact next tool/service (no wildcards)
+- **MUST** AUTH-005: Access token TTL ≤ 10 minutes (shorter for sensitive tools)
+- **MUST** AUTH-006: JWKS cache ≤ 15 minutes; deny unknown `kid`; rotation SOP
+- **SHOULD** AUTH-008: RFC 8693 Token Exchange per hop (re-bind audience)
+- **SHOULD** AUTH-009: Deny on missing `aud`/`trace_id`; fail-safe default
+
+## Implementation pattern (per hop)
+1. **Token Exchange**: Exchange incoming token for a new token with `aud=<next>` and TTL ≤ 10m.
+2. **Bind PoP**: Use DPoP (HTTP) or mTLS (gateway) so token is sender-constrained.
+3. **Validate**: On receipt, verify `aud`, TTL, PoP, and `kid` exists in current JWKS.
+4. **Emit telemetry**: Log fields from `docs/auth/telemetry-schema.md` (incl. `trace_id`, `aud`, `jti`, `dpop_jkt`).
+5. **Deny on context loss**: If `aud` mismatched/missing or PoP not present → hard deny + audit event.
+
+## Example enforcement pseudo
+
+## Example enforcement pseudo
+
+
+**References.**
+- `docs/auth/threat-control-matrix.md`
+- `docs/auth/flows/headless-agent.md`
+- RFC 8693 (Token Exchange)

--- a/runbooks/jwks-rotation-sop.md
+++ b/runbooks/jwks-rotation-sop.md
@@ -1,0 +1,19 @@
+# Runbook: JWKS Rotation (SAFE-AUTH)
+
+## Preconditions
+- Dual-key signer ready (KMS/HSM).
+- Monitoring: unknown `kid`, cache age, 5xx on JWKS fetch.
+
+## Steps
+1) **Prepare key**: generate new key; publish to JWKS with new `kid`; keep old key active.
+2) **Announce**: change ticket; notify on-call; schedule rotation window (≤ 60m).
+3) **Deploy**: roll app to sign tokens with new key; verify audience accepts.
+4) **Observe** (15–30m):
+   - unknown `kid`: 0
+   - cache age: P95 < 15m
+   - error rate: baseline
+5) **Deactivate old key**: remove old key from JWKS (within the same window).
+6) **Close out**: attach evidence (graphs, logs); set next rotation reminder (≤ 30d).
+
+## Rollback
+- Re-add old key to JWKS; revert signer; postmortem with cache age + error timelines.


### PR DESCRIPTION
Adds actionable JWKS hygiene:

- docs/auth/jwks-hygiene.md — MUST/SHOULD guidance (cache ≤15m, deny unknown kid, overlap window, rotation cadence) + telemetry fields.
- runbooks/jwks-rotation-sop.md — step-by-step rotation with verify/rollback.
- alerts/jwks-hygiene.md — unknown kid, stale cache, window exceeded, key age.

Linked from docs/auth/overview.md (+ evidence hints in checklist).

Why: reduces replay/impersonation risk from stale or rogue keys and makes AUTH-006 auditable.