### PR TITLE
docs(auth): abuse-controls — per-tool/client rate limits + backoff; pseudo + Envoy/NGINX examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,7 @@ The SAFE-MCP framework defines 14 tactics that align with the MITRE ATT&CK metho
 - Map these techniques to your specific MCP deployment for risk assessment
 - Prioritize mitigation based on your threat model and the techniques most relevant to your environment
 - Regular review as new techniques emerge in the rapidly evolving MCP threat landscape
+
+## Authentication
+
+See **[SAFE-AUTH for MCP](./docs/auth/overview.md)** for baseline flows and the MUST/SHOULD checklist.

--- a/alerts/jwks-hygiene.md
+++ b/alerts/jwks-hygiene.md
@@ -1,0 +1,17 @@
+# Alerts: JWKS Hygiene
+
+- **Unknown kid deny**
+  - Condition: `result == "deny_unknown_kid"` (rate > 0 for 2m)
+  - Action: page on-call; create incident.
+
+- **Stale JWKS cache**
+  - Condition: `jwks_cache_age_ms > 900000` sustained 5m (per issuer)
+  - Action: warn (SLO); if > 20m escalate.
+
+- **Rotation window exceeded**
+  - Condition: both old+new keys observed > 60m
+  - Action: ticket + on-call notification.
+
+- **Key age exceeds policy**
+  - Condition: signer `kid` unchanged > 90d
+  - Action: ticket; schedule rotation.

--- a/docs/auth/abuse-controls.md
+++ b/docs/auth/abuse-controls.md
@@ -1,0 +1,77 @@
+# SAFE-AUTH: Rate-limit & Abuse Controls
+
+**Goal.** Keep auth/tool surfaces resilient under load/misuse. Prefer cheap gates early; deny safely when limits trip.
+
+## MUST
+- **Per-tool limits**: enforce a token-bucket or leaky-bucket per `tool` (target path).
+- **Per-client limits**: limit by `client_id` (agent) and/or `sub_or_user` (human).
+- **Fast pre-filter**: cheap per-IP or per-connection limit *before* expensive auth or token introspection.
+- **Fail-safe default**: when limiter/cache is unavailable, default to conservative ceilings (deny or hard backoff).
+- **Emit telemetry** on limit decisions (see fields below).
+
+## SHOULD
+- **Burst control**: allow small bursts; sustained rate must stay under ceiling.
+- **Backoff on fails**: increase penalty for repeated 401/403/429 from the same key.
+- **Circuit-break hot tools**: temporarily shed traffic when a tool’s 5xx spikes.
+- **Separate write vs read**: stricter ceilings for mutating tools.
+
+## Suggested ceilings (tune per env)
+- Read tools: **60/min** per `(tool, client_id)` with burst 20.
+- Write tools: **10/min** per `(tool, client_id)` with burst 5.
+- Pre-filter per-IP: **120/min** with burst 60 (cheap SYN flood brake).
+
+## Telemetry (recommend adding to your v1 record)
+- `rl_key`  (string)  — e.g., `tool=tools/ingest|client=agent-42`
+- `rl_bucket` (string) — `per_tool`, `per_client`, `per_ip`, `circuit_breaker`
+- `rl_limit`  (string) — `60/m burst=20`
+- `rl_result` (enum)  — `allow`, `throttle`, `deny`
+- Existing: `trace_id`, `tool`, `client_id`, `sub_or_user`, `result`
+
+## Hunting/alerts (queries)
+- Spike of `rl_result=deny` grouped by `rl_key` or `client_id`.
+- >3 denies/min for same `jti` or same `dpop_jkt` → blocklist or CAPTCHA.
+- `result=deny` + `status=401/403` loops from same IP over 5 min → raise.
+
+## Enforcement pseudo
+
+```text
+key_tool    = "tool=" + tool_id
+key_client  = key_tool + "|client=" + client_id_or_user
+
+if !pre_ip_limiter.allow(ip):        return 429, rl(per_ip, deny)
+if !tool_limiter.allow(key_tool):    return 429, rl(per_tool, deny)
+if !client_limiter.allow(key_client):return 429, rl(per_client, deny)
+
+// Optionally: penalize on recent 401/403 from same client
+if recent_denies(key_client) > N:    return 429, rl(backoff, deny)
+
+forward_request()
+
+
+## 2) Gateway examples (pseudo + tiny Envoy / NGINX samples)
+
+```bash
+cat > examples/gateway/rate-limit-pseudo.md <<'EOF'
+# Rate-limit Pseudo (language/gateway agnostic)
+
+buckets = {
+  per_ip:     token_bucket(cap=120, refill=120/min, burst=60),
+  per_tool:   token_bucket(cap=60,  refill=60/min,  burst=20),
+  per_client: token_bucket(cap=60,  refill=60/min,  burst=20),
+  per_write:  token_bucket(cap=10,  refill=10/min,  burst=5),
+}
+
+route = route_from_url(req.url)           // e.g., /tools/ingest
+tool_id = canonical_tool(route)
+is_write = method in ["POST","PUT","PATCH","DELETE"]
+
+ip_key = req.ip
+tool_key = tool_id
+client_key = tool_id + "|" + (req.client_id || req.user_id)
+
+if !buckets.per_ip.allow(ip_key)     -> 429
+if is_write && !buckets.per_write.allow(tool_key) -> 429
+if !buckets.per_tool.allow(tool_key) -> 429
+if !buckets.per_client.allow(client_key) -> 429
+
+// else allow; emit telemetry with rl_* fields

--- a/docs/auth/checklist.md
+++ b/docs/auth/checklist.md
@@ -2,3 +2,5 @@
 > Evidence ideas for AUTH-006: deny logs for unknown kid, JWKS cache-age panel, rotation ticket <=30d.
 
 > Evidence ideas for AUTH-003: deny logs for DPoP replay/mismatch, chart of replay-cache hits, config showing DPoP enabled on tool routes.
+
+> Evidence ideas for AUTH-010: limiter config, rl_result time-series, block/backoff runbook.

--- a/docs/auth/checklist.md
+++ b/docs/auth/checklist.md
@@ -1,0 +1,2 @@
+
+> Evidence ideas for AUTH-006: deny logs for unknown kid, JWKS cache-age panel, rotation ticket <=30d.

--- a/docs/auth/checklist.md
+++ b/docs/auth/checklist.md
@@ -1,2 +1,4 @@
 
 > Evidence ideas for AUTH-006: deny logs for unknown kid, JWKS cache-age panel, rotation ticket <=30d.
+
+> Evidence ideas for AUTH-003: deny logs for DPoP replay/mismatch, chart of replay-cache hits, config showing DPoP enabled on tool routes.

--- a/docs/auth/conformance-template.yaml
+++ b/docs/auth/conformance-template.yaml
@@ -1,0 +1,67 @@
+# SAFE-AUTH Conformance Template
+# status: todo | partial | done
+meta:
+  system: "<name>"
+  owner: "<team-or-contact>"
+  reviewed_at: "<YYYY-MM-DD>"
+
+controls:
+  - id: AUTH-001
+    name: OIDC Authorization Code + PKCE
+    level: MUST
+    status: todo
+    evidence: ["<oidc client config>"]
+
+  - id: AUTH-002
+    name: state + nonce + issuer pinning
+    level: MUST
+    status: todo
+    evidence: []
+
+  - id: AUTH-003
+    name: DPoP or mTLS token binding
+    level: MUST
+    status: todo
+    evidence: ["<gateway/policy link>"]
+
+  - id: AUTH-004
+    name: aud = exact next tool/service
+    level: MUST
+    status: todo
+    evidence: ["<JWT sample showing aud>"]
+
+  - id: AUTH-005
+    name: Access token TTL ≤ 10 minutes
+    level: MUST
+    status: todo
+    evidence: []
+
+  - id: AUTH-006
+    name: JWKS cache ≤ 15 minutes + rotation SOP
+    level: MUST
+    status: todo
+    evidence: ["<rotation runbook link>"]
+
+  - id: AUTH-007
+    name: Structured telemetry fields present per call
+    level: MUST
+    status: todo
+    evidence: ["<log sample>"]
+
+  - id: AUTH-008
+    name: RFC 8693 Token Exchange per hop
+    level: SHOULD
+    status: partial
+    evidence: []
+
+  - id: AUTH-009
+    name: Deny on context loss (missing aud/trace_id)
+    level: SHOULD
+    status: partial
+    evidence: []
+
+  - id: AUTH-010
+    name: Rate-limit auth endpoints & tool calls
+    level: SHOULD
+    status: partial
+    evidence: []

--- a/docs/auth/dpop-policy.md
+++ b/docs/auth/dpop-policy.md
@@ -1,0 +1,43 @@
+# SAFE-AUTH: DPoP Gateway Policy
+
+**Goal.** Bind access tokens to the caller so they cannot be replayed from another client or network hop.
+
+## MUST
+- **Require DPoP** for tool endpoints that accept OAuth access tokens over HTTP/1.1 or HTTP/2.
+- **Verify DPoP proof** per request:
+  - `htu` matches the request URL (scheme/host/path) and `htm` matches method.
+  - `iat` within skew window (≤ 5 minutes).
+  - `jti` not seen before within TTL window (replay cache).
+  - DPoP proof JWT signature valid with public key in JWK thumbprint.
+- **Bind access token to DPoP key**:
+  - Access token contains `cnf.jkt` (SHA-256 JWK thumbprint).
+  - The DPoP proof public key thumbprint equals `cnf.jkt`.
+  - Deny when `cnf.jkt` missing or mismatch.
+- **Emit telemetry** (see fields below) and **hard-deny** on failures.
+
+## SHOULD
+- Enforce **per-path policy** (e.g., admin tools require DPoP; read-only may allow mTLS alternative).
+- Expire replay cache entries on a sliding TTL ≤ token TTL (max 10m).
+- Backpressure/ratelimit on repeated DPoP failures from same client/IP.
+
+## Telemetry fields (add to your schema v1 record)
+- `dpop_jkt` (string) — DPoP key thumbprint
+- `dpop_result` (`success|deny_mismatch_jkt|deny_replay|deny_invalid_proof|deny_missing`)
+- `dpop_jti` (string) — proof JWT id
+- `tool`, `aud`, `jti`, `trace_id`, `result` (existing)
+
+## Deny conditions
+- Missing DPoP when policy requires → `deny_missing`
+- Invalid proof (sig/iat/htm/htu) → `deny_invalid_proof`
+- Replay `jti` seen within window → `deny_replay`
+- `cnf.jkt` missing in token or ≠ proof key thumbprint → `deny_mismatch_jkt`
+
+## Evidence to attach
+- Log excerpt showing deny on `deny_mismatch_jkt`
+- Replay cache hit metric panel
+- Config snippet enabling DPoP for tool routes
+
+## References
+- OAuth DPoP (draft-ietf-oauth-dpop)
+- SAFE-AUTH Checklist: AUTH-003 (DPoP or mTLS binding)
+- Telemetry schema v1 + validators

--- a/docs/auth/jwks-hygiene.md
+++ b/docs/auth/jwks-hygiene.md
@@ -1,0 +1,37 @@
+# SAFE-AUTH: JWKS Hygiene & Rotation
+
+**Why it matters.** Stale or mismatched keys let attackers replay or impersonate tokens; unknown `kid` lets rogue keys slip in; long rotation windows widen blast radius.
+
+## MUST
+- **Cache TTL ≤ 15 minutes** for issuer JWKS.
+- **Deny unknown `kid`** (hard fail; emit audit).
+- **Overlapping rotation window ≤ 1 hour** (old+new keys concurrently valid).
+- **Alert on cache age > TTL** (fetch failures or stuck caches).
+
+## SHOULD
+- **Rotation cadence ≤ 30 days** (shorter for high-risk).
+- **No static keys**; automation only.
+- **Key provenance** recorded (KMS/CloudHSM).
+
+## Telemetry (per auth decision)
+Record at least:
+- `trace_id`, `aud`, `jti`, `kid`, `jwks_cache_age_ms`, `jwks_source` (`remote|cache`), `result` (`success|deny_unknown_kid|deny_stale_jwks|error`).
+
+## Alerts (see alerts/jwks-hygiene.md)
+- Unknown `kid` deny.
+- `jwks_cache_age_ms` > 15m for >5m.
+- Rotation overlap > 60m.
+- Same `kid` age > 90d.
+
+## Runbook (see runbooks/jwks-rotation-sop.md)
+- Pre-announce, rotate, verify, and rollback steps with checkpoints.
+
+## Evidence to attach (for checklist)
+- Screenshot/log of deny-on-unknown-kid.
+- Monitoring panel showing JWKS cache age distribution.
+- Rotation change record (ticket/PR) within 30d.
+
+## References
+- RFC 7517 (JWK), RFC 7518/7519 (JWS/JWT)
+- SAFE-AUTH Checklist: AUTH-006 (JWKS cache ≤ 15m; deny unknown `kid`)
+- Telemetry schema v1 + validators

--- a/docs/auth/overview.md
+++ b/docs/auth/overview.md
@@ -64,3 +64,5 @@ cat > docs/auth/checklist.md <<'EOF'
 - JWKS Hygiene: see [docs/auth/jwks-hygiene.md](./docs/auth/jwks-hygiene.md), [alerts/jwks-hygiene.md](./alerts/jwks-hygiene.md), and [runbooks/jwks-rotation-sop.md](./runbooks/jwks-rotation-sop.md).
 
 - DPoP policy & pseudo: see [docs/auth/dpop-policy.md](./docs/auth/dpop-policy.md) and [examples/gateway/](./examples/gateway).
+
+- Rate-limit & abuse controls: see [docs/auth/abuse-controls.md](./docs/auth/abuse-controls.md) and [examples/gateway/](./examples/gateway).

--- a/docs/auth/overview.md
+++ b/docs/auth/overview.md
@@ -62,3 +62,5 @@ cat > docs/auth/checklist.md <<'EOF'
   [Sample NDJSON](../../examples/telemetry/sample.ndjson)
 
 - JWKS Hygiene: see [docs/auth/jwks-hygiene.md](./docs/auth/jwks-hygiene.md), [alerts/jwks-hygiene.md](./alerts/jwks-hygiene.md), and [runbooks/jwks-rotation-sop.md](./runbooks/jwks-rotation-sop.md).
+
+- DPoP policy & pseudo: see [docs/auth/dpop-policy.md](./docs/auth/dpop-policy.md) and [examples/gateway/](./examples/gateway).

--- a/docs/auth/overview.md
+++ b/docs/auth/overview.md
@@ -1,0 +1,58 @@
+<!-- Licensed under CC-BY-4.0 -->
+
+# SAFE-AUTH for MCP — Overview
+
+**Goal.** Provide a vendor-neutral authentication baseline so MCP implementations are **safe by default** for humans, headless agents, and tool servers.
+
+## Design principles
+- **Least privilege per tool**: scopes and **audience** are bound to the *next hop* (specific tool/service), never broad.
+- **Short-lived tokens** bound to the caller (**DPoP or mTLS**) to kill replay.
+- **Explicit delegation** across agent→agent→tool hops (token **exchange** each hop; never forward a broad token).
+- **Observable by design**: structured telemetry on every tool call for audits and incident response.
+
+## Roles in MCP auth
+- **Human Operator** (user)
+- **MCP Client/Agent** (orchestrates tools)
+- **MCP Server / Tool Host** (executes tool calls)
+- **Authorization Server (AS)** (OIDC/OAuth2 provider)
+
+## Threats this baseline addresses
+- **Authorization server mix-up / CSRF** → OIDC Authorization Code **with PKCE**, `state`, `nonce`, **issuer pinning**.
+- **Token replay** → **DPoP or mTLS** token binding + access token **TTL ≤ 10 minutes**.
+- **Token audience confusion** (token reused across tools) → token `aud` **must equal the exact next tool/service**.
+- **Delegation drift** (multi-agent hops drop user/intent context) → **RFC 8693 Token Exchange** per hop + re-bind `aud`.
+- **JWKS staleness / `kid` collision** → JWKS **cache ≤ 15m**, overlap rotation, strict deny on unknown `kid`.
+
+## Canonical flows (mermaid)
+### Human → MCP Client → MCP Server (OIDC Auth Code + PKCE)
+```mermaid
+sequenceDiagram
+participant User
+participant Client as MCP Client
+participant AS as Authorization Server
+participant Server as MCP Server/Tool
+User->>Client: Start sign-in
+Client->>AS: /authorize (response_type=code, PKCE, state, nonce)
+AS-->>Client: Auth code (redirect)
+Client->>AS: /token (code + code_verifier)
+AS-->>Client: access_token (bound via DPoP/mTLS), id_token
+Client->>Server: Tool call (Authorization: DPoP <proof>; token aud=Server)
+Server-->>Client: Result (+ audit_id)
+
+cat > docs/auth/checklist.md <<'EOF'
+<!-- Licensed under CC-BY-4.0 -->
+
+# SAFE-AUTH Checklist (MUST / SHOULD / MAY)
+
+| Level | Control | Why |
+|---|---|---|
+| **MUST** | Human login uses **OIDC Authorization Code + PKCE** (no implicit) with `state`, `nonce`, issuer pinning | Prevent code interception, AS mix-up, CSRF |
+| **MUST** | Machine/agent calls use **DPoP or mTLS** token binding | Prevent replay |
+| **MUST** | **Audience (`aud`) per hop = exact next tool/service** | Stop token reuse across tools |
+| **MUST** | **Access token TTL ≤ 10 minutes** | Shrink exfiltration window |
+| **MUST** | **JWKS cache ≤ 15 minutes** and rotation SOP | Avoid stale keys / `kid` swap |
+| **MUST** | **Structured telemetry** per call | Audits & forensics |
+| **SHOULD** | **RFC 8693 Token Exchange** per hop | Preserve delegation context |
+| **SHOULD** | Deny on context loss | Fail-safe default |
+| **SHOULD** | Rate-limit auth endpoints | Abuse control |
+| **MAY** | PAR/JAR, CAEP, continuous eval | Hardening options |

--- a/docs/auth/overview.md
+++ b/docs/auth/overview.md
@@ -56,3 +56,7 @@ cat > docs/auth/checklist.md <<'EOF'
 | **SHOULD** | Deny on context loss | Fail-safe default |
 | **SHOULD** | Rate-limit auth endpoints | Abuse control |
 | **MAY** | PAR/JAR, CAEP, continuous eval | Hardening options |
+
+- Telemetry: [Schema](./telemetry-schema.md) ·
+  [Validators](./telemetry-validators.md) ·
+  [Sample NDJSON](../../examples/telemetry/sample.ndjson)

--- a/docs/auth/overview.md
+++ b/docs/auth/overview.md
@@ -60,3 +60,5 @@ cat > docs/auth/checklist.md <<'EOF'
 - Telemetry: [Schema](./telemetry-schema.md) ·
   [Validators](./telemetry-validators.md) ·
   [Sample NDJSON](../../examples/telemetry/sample.ndjson)
+
+- JWKS Hygiene: see [docs/auth/jwks-hygiene.md](./docs/auth/jwks-hygiene.md), [alerts/jwks-hygiene.md](./alerts/jwks-hygiene.md), and [runbooks/jwks-rotation-sop.md](./runbooks/jwks-rotation-sop.md).

--- a/docs/auth/telemetry-schema.md
+++ b/docs/auth/telemetry-schema.md
@@ -1,0 +1,8 @@
+
+## Validators
+See [telemetry-validators](./telemetry-validators.md) and
+[sample NDJSON](../../examples/telemetry/sample.ndjson).
+
+## Validators
+See [telemetry-validators](./telemetry-validators.md) and
+[sample NDJSON](../../examples/telemetry/sample.ndjson).

--- a/docs/auth/telemetry-validators.md
+++ b/docs/auth/telemetry-validators.md
@@ -1,0 +1,37 @@
+# SAFE-AUTH Telemetry Validators (v1)
+
+**Required per call:** `trace_id`, `ts`, `tool`, `client_id`, `sub_or_user`, `aud`, `jti`, and `dpop_jkt` when PoP policy is enabled.
+
+## Reject if
+- `aud` ≠ invoked tool/service id
+- `jti` is reused within the token TTL window
+- `dpop_jkt` missing when PoP is required
+- `trace_id` missing or empty
+
+## Recommended checks
+- Clock skew ≤ 60s between `ts` values on same `trace_id`
+- Monotonic `ts` per `trace_id`
+- Result not `"success"` without an auth decision log
+
+## Example (NDJSON)
+See `examples/telemetry/sample.ndjson`.
+
+## Quick local checks (jq)
+```bash
+# 1) Missing trace_id
+jq -c 'select(has("trace_id")|not)' examples/telemetry/sample.ndjson
+
+# 2) aud mismatch (expect mcp://tool/ingest)
+jq -c 'select(.aud != "mcp://tool/ingest")' examples/telemetry/sample.ndjson
+
+# 3) Duplicate jti within the file (naive local check)
+jq -r .jti examples/telemetry/sample.n
+
+
+---
+
+### 3) Append a tiny “Validators” section to your existing schema (safe even if it already exists)
+```bash
+printf "\n## Validators\nSee [telemetry-validators](./telemetry-validators.md) and [sample NDJSON](../../examples/telemetry/sample.ndjson).\n" >> docs/auth/telemetry-schema.md
+
+eof

--- a/docs/auth/threat-control-matrix.md
+++ b/docs/auth/threat-control-matrix.md
@@ -1,0 +1,12 @@
+<!-- Licensed under CC-BY-4.0 -->
+
+# Threat → Control Matrix (SAFE-AUTH)
+
+| Threat | Primary Controls (MUST) | Secondary (SHOULD/MAY) | Evidence to Collect |
+|---|---|---|---|
+| AS mix-up / CSRF | OIDC Auth Code + **PKCE**, `state`, `nonce`, **issuer pinning** | PAR/JAR | OIDC client config, redirect URI list, issuer metadata |
+| Token replay | **DPoP or mTLS** binding; **TTL ≤10m** | CAEP/continuous evaluation | DPoP verification logs, TLS/mTLS policy, token lifetime |
+| Token audience confusion | **`aud` = exact next tool/service** | Per-tool scope map | JWT sample with `aud`, tool registry mapping |
+| Delegation drift (multi-hop) | **RFC 8693 Token Exchange** per hop; re-bind `aud` | Deny on missing `trace_id` / `aud` | Token Exchange config, hop-by-hop logs |
+| JWKS staleness / `kid` collision | **JWKS cache ≤15m**; rotation SOP; deny unknown `kid` | Overlap-period alerts | JWKS headers, rotation runbook, error logs |
+| Observability gap | **Structured telemetry on every tool call** | Centralized log routing | Field schema adoption, sample NDJSON |

--- a/examples/gateway/README.md
+++ b/examples/gateway/README.md
@@ -1,0 +1,12 @@
+# Gateway DPoP Enforcement (Pseudo)
+
+Minimal steps your gateway/filter should perform:
+
+1) Extract `DPoP` header and access token.
+2) Parse DPoP JWT: check `htm`, `htu`, `iat` (<= 300s skew), and unique `jti`.
+3) Verify DPoP JWT signature against embedded JWK; compute JWK thumbprint (`jkt`).
+4) Decode access token; read `cnf.jkt`; require `cnf.jkt == dpop_jkt`.
+5) On success, forward request with `dpop_jkt` attached to auth context and emit telemetry.
+6) On failure, return 401/403 and emit structured denial telemetry.
+
+See `dpop-verify-pseudo.md` for language-agnostic pseudo-code.

--- a/examples/gateway/dpop-verify-pseudo.md
+++ b/examples/gateway/dpop-verify-pseudo.md
@@ -1,0 +1,30 @@
+# DPoP Verify (Language-agnostic Pseudo)
+
+input: request(method, url, headers), access_token
+
+proof = parse_jwt(headers["DPoP"])
+require proof.header.typ == "dpop+jwt"
+require proof.claims.htm == request.method
+require proof.claims.htu == canonicalize(request.url)
+require now - proof.claims.iat <= 300  // 5 min
+require replay_cache.add_if_new(proof.claims.jti)  // false => replay
+
+// verify DPoP signature
+pubkey = proof.header.jwk
+require verify_signature(proof, pubkey)
+
+// compute thumbprint of pubkey (RFC 7638)
+dpop_jkt = sha256_jwk_thumbprint(pubkey)
+
+// bind access token to DPoP key
+token = decode_jwt(access_token)
+require token.cnf.jkt exists
+require token.cnf.jkt == dpop_jkt
+
+emit_telemetry({
+  trace_id, aud: token.aud, jti: token.jti,
+  dpop_jkt, dpop_jti: proof.claims.jti, dpop_result: "success",
+  tool, result: "success"
+})
+
+forward_request()

--- a/examples/gateway/rate-limit-envoy.yaml
+++ b/examples/gateway/rate-limit-envoy.yaml
@@ -1,0 +1,27 @@
+# Envoy HTTP local rate limit (minimal example)
+# Attach this filter on the HTTP connection manager or per-route.
+
+http_filters:
+- name: envoy.filters.http.local_ratelimit
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+    stat_prefix: local_rate_limit
+    token_bucket:
+      max_tokens: 60
+      tokens_per_fill: 60
+      fill_interval: 60s
+    filter_enabled:
+      runtime_key: local_rate_limit_enabled
+      default_value:
+        numerator: 100
+        denominator: HUNDRED
+    filter_enforced:
+      default_value:
+        numerator: 100
+        denominator: HUNDRED
+    response_headers_to_add:
+    - header:
+        key: x-rate-limit-bucket
+        value: per_tool
+      append_action: APPEND_IF_EXISTS_OR_ADD
+# For per-client, add a second LocalRateLimit at a lower route stage with header-based descriptors

--- a/examples/gateway/rate-limit-nginx.conf
+++ b/examples/gateway/rate-limit-nginx.conf
@@ -1,0 +1,15 @@
+# NGINX minimal example (tune sizes/rates!)
+# http { ... }
+limit_req_zone $binary_remote_addr zone=per_ip:10m rate=2r/s;        # ~120/min
+limit_req_zone $http_x_client_id   zone=per_client:10m rate=1r/s;    # 60/min
+map $request_uri $tool_bucket { default per_tool_default; }
+limit_req_zone $tool_bucket zone=per_tool:10m rate=1r/s;             # 60/min
+
+server {
+  location /tools/ {
+    limit_req zone=per_ip    burst=60 nodelay;
+    limit_req zone=per_tool  burst=20 nodelay;
+    limit_req zone=per_client burst=20 nodelay;
+    proxy_pass http://tool-backend;
+  }
+}

--- a/examples/gateway/rate-limit-pseudo.md
+++ b/examples/gateway/rate-limit-pseudo.md
@@ -1,0 +1,23 @@
+# Rate-limit Pseudo (language/gateway agnostic)
+
+buckets = {
+  per_ip:     token_bucket(cap=120, refill=120/min, burst=60),
+  per_tool:   token_bucket(cap=60,  refill=60/min,  burst=20),
+  per_client: token_bucket(cap=60,  refill=60/min,  burst=20),
+  per_write:  token_bucket(cap=10,  refill=10/min,  burst=5),
+}
+
+route = route_from_url(req.url)           // e.g., /tools/ingest
+tool_id = canonical_tool(route)
+is_write = method in ["POST","PUT","PATCH","DELETE"]
+
+ip_key = req.ip
+tool_key = tool_id
+client_key = tool_id + "|" + (req.client_id || req.user_id)
+
+if !buckets.per_ip.allow(ip_key)     -> 429
+if is_write && !buckets.per_write.allow(tool_key) -> 429
+if !buckets.per_tool.allow(tool_key) -> 429
+if !buckets.per_client.allow(client_key) -> 429
+
+// else allow; emit telemetry with rl_* fields

--- a/examples/telemetry/sample.ndjson
+++ b/examples/telemetry/sample.ndjson
@@ -1,0 +1,2 @@
+{"trace_id":"tr_001","ts":"2025-08-16T19:20:30Z","tool":"mcp://tool/ingest","client_id":"agent-42","sub_or_user":"user-123","aud":"mcp://tool/ingest","jti":"jti-001","dpop_jkt":"thp-abc123","method":"POST","target":"/tools/ingest","result":"success"}
+{"trace_id":"tr_001","ts":"2025-08-16T19:20:31Z","tool":"mcp://tool/ingest","client_id":"agent-42","sub_or_user":"user-123","aud":"mcp://tool/ingest","jti":"jti-002","dpop_jkt":"thp-abc123","method":"POST","target":"/tools/ingest","result":"success"}

--- a/mitigations/SAFE-M1001-auth-delegation.md
+++ b/mitigations/SAFE-M1001-auth-delegation.md
@@ -1,0 +1,30 @@
+<!-- Licensed under CC-BY-4.0 -->
+
+# SAFE-M1001: Per-Hop Delegation Mitigations
+
+**Objective.** Ensure every hop in a delegation chain has a *fresh*, *narrow*, and *proof-of-possession* bound token for the exact next audience.
+
+## Controls (map to checklist IDs)
+- **MUST** AUTH-003: DPoP or mTLS binding on all tokens used for tool calls
+- **MUST** AUTH-004: `aud` = exact next tool/service (no wildcards)
+- **MUST** AUTH-005: Access token TTL ≤ 10 minutes (shorter for sensitive tools)
+- **MUST** AUTH-006: JWKS cache ≤ 15 minutes; deny unknown `kid`; rotation SOP
+- **SHOULD** AUTH-008: RFC 8693 Token Exchange per hop (re-bind audience)
+- **SHOULD** AUTH-009: Deny on missing `aud`/`trace_id`; fail-safe default
+
+## Implementation pattern (per hop)
+1. **Token Exchange**: Exchange incoming token for a new token with `aud=<next>` and TTL ≤ 10m.
+2. **Bind PoP**: Use DPoP (HTTP) or mTLS (gateway) so token is sender-constrained.
+3. **Validate**: On receipt, verify `aud`, TTL, PoP, and `kid` exists in current JWKS.
+4. **Emit telemetry**: Log fields from `docs/auth/telemetry-schema.md` (incl. `trace_id`, `aud`, `jti`, `dpop_jkt`).
+5. **Deny on context loss**: If `aud` mismatched/missing or PoP not present → hard deny + audit event.
+
+## Example enforcement pseudo
+
+## Example enforcement pseudo
+
+
+**References.**
+- `docs/auth/threat-control-matrix.md`
+- `docs/auth/flows/headless-agent.md`
+- RFC 8693 (Token Exchange)

--- a/runbooks/jwks-rotation-sop.md
+++ b/runbooks/jwks-rotation-sop.md
@@ -1,0 +1,19 @@
+# Runbook: JWKS Rotation (SAFE-AUTH)
+
+## Preconditions
+- Dual-key signer ready (KMS/HSM).
+- Monitoring: unknown `kid`, cache age, 5xx on JWKS fetch.
+
+## Steps
+1) **Prepare key**: generate new key; publish to JWKS with new `kid`; keep old key active.
+2) **Announce**: change ticket; notify on-call; schedule rotation window (≤ 60m).
+3) **Deploy**: roll app to sign tokens with new key; verify audience accepts.
+4) **Observe** (15–30m):
+   - unknown `kid`: 0
+   - cache age: P95 < 15m
+   - error rate: baseline
+5) **Deactivate old key**: remove old key from JWKS (within the same window).
+6) **Close out**: attach evidence (graphs, logs); set next rotation reminder (≤ 30d).
+
+## Rollback
+- Re-add old key to JWKS; revert signer; postmortem with cache age + error timelines.


### PR DESCRIPTION
This PR adds concrete SAFE-AUTH abuse-controls with working examples and gateway-agnostic pseudo.

Adds
- docs/auth/abuse-controls.md — guidance + evidence ideas (limiters, CI time-series, block/backoff runbook).
- examples/gateway/rate-limit-pseudo.md — language/gateway-agnostic reference (per IP / tool / client / write).
- examples/gateway/rate-limit-envoy.yaml — Envoy example (listener/local_ratelimit).
- examples/gateway/rate-limit-nginx.conf — NGINX example (limit_req + burst/nodelay).
- README/overview/checklist tweaks to link to the above.

Why
- Prevent burst/abuse across tools and clients with default-deny/backoff patterns.
- Provide copy-pasteable starting points that teams can drop into gateways today.
- Make audit evidence concrete (configs in repo, CI plots, runbooks).

Notes
- Scopes/thresholds are illustrative; maintainers can tune caps and bursts per deployment.
- Happy to split or refine if reviewers prefer smaller units.